### PR TITLE
Feature/gitattributes for syntax highlighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Declare Github Syntax Highlighting for various file types
+# https://github.com/github-linguist/linguist/blob/master/lib/linguist/languages.yml
+mmt/css/*.mvt linguist-language=CSS
+mmt/js/*.mvt linguist-language=JavaScript
+mmt/**/*.mvt linguist-language=XML

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,5 @@
 # https://github.com/github-linguist/linguist/blob/master/lib/linguist/languages.yml
 mmt/css/*.mvt linguist-language=CSS
 mmt/js/*.mvt linguist-language=JavaScript
-mmt/**/*.mvt linguist-language=XML
+mmt/properties/*.mvt linguist-language=XML
+mmt/templates/*.mvt linguist-language=XML


### PR DESCRIPTION
Added [linguist-language definitions](https://github.com/github-linguist/linguist/blob/master/lib/linguist/languages.yml) to .gitattributes to [override/correct Github's syntax highlighting](https://github.com/github-linguist/linguist/blob/master/docs/overrides.md)